### PR TITLE
Show user notification in current language [PLA-30]

### DIFF
--- a/src/hooks/use-profile.ts
+++ b/src/hooks/use-profile.ts
@@ -57,10 +57,12 @@ export const useProfile = () => {
             return data;
         },
         {
-            onSuccess: () => {
+            onSuccess: (_, { language }) => {
                 showNotification({
-                    title: t('notification.success.title'),
-                    message: t('notification.success.message'),
+                    title: t('notification.success.title', { lng: language }),
+                    message: t('notification.success.message', {
+                        lng: language,
+                    }),
                 });
 
                 queryClient.invalidateQueries(['user']);


### PR DESCRIPTION
There is a bug when the user changes their language, they are shown the success message in the previously set language. This PR fixes this issue, by taking the new language from the request payload.