### PR TITLE
Show texts in current user language [PLA-34]

### DIFF
--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -3,7 +3,6 @@ import { createPagesServerClient } from '@supabase/auth-helpers-nextjs';
 import { endOfDay, startOfDay } from 'date-fns';
 import { fromPairs, map } from 'lodash';
 import { type GetServerSideProps } from 'next';
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import invariant from 'tiny-invariant';
 
 import { getServerSession } from '~api/session';
@@ -15,6 +14,7 @@ import { CurrentFat, FatTimeline } from '~features/fat-percent';
 import { type MealsMap } from '~types/meal';
 import { type Database } from '~types/supabase';
 import { getUTCDate } from '~util/date';
+import { getServerSideTranslations } from '~util/i18n';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
     const supabase = createPagesServerClient<Database>(context);
@@ -53,9 +53,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         props: {
             dailyMeals,
             user,
-            ...(await serverSideTranslations(profile?.language || 'en', [
-                'common',
-            ])),
+            ...(await getServerSideTranslations({ locale: profile?.language })),
         },
     };
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,9 @@
 import { Center, List, Stack, Text, Title } from '@mantine/core';
 import type { GetServerSideProps } from 'next';
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 
 import { getServerSession } from '~api/session';
 import { Blobs, Line } from '~components/icons/line';
+import { getServerSideTranslations } from '~util/i18n';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
     const session = await getServerSession(context);
@@ -19,7 +19,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
     return {
         props: {
-            ...(await serverSideTranslations('en', ['common'])),
+            ...(await getServerSideTranslations({ locale: 'en' })),
         },
     };
 };

--- a/src/pages/meal-plan.tsx
+++ b/src/pages/meal-plan.tsx
@@ -1,12 +1,12 @@
 import { createPagesServerClient } from '@supabase/auth-helpers-nextjs';
 import { type GetServerSideProps } from 'next';
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import invariant from 'tiny-invariant';
 
 import { getServerSession } from '~api/session';
 import { fetchUser } from '~api/user';
 import { Calendar } from '~features/calendar';
 import { type Database } from '~types/supabase';
+import { getServerSideTranslations } from '~util/i18n';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
     const supabase = createPagesServerClient<Database>(context);
@@ -30,9 +30,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
     return {
         props: {
-            ...(await serverSideTranslations(profile?.language || 'en', [
-                'common',
-            ])),
+            ...(await getServerSideTranslations({ locale: profile?.language })),
         },
     };
 };

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -15,7 +15,6 @@ import { createPagesServerClient } from '@supabase/auth-helpers-nextjs';
 import { useSupabaseClient } from '@supabase/auth-helpers-react';
 import { type GetServerSideProps } from 'next';
 import { useTranslation } from 'next-i18next';
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import { useState } from 'react';
 import { useQuery } from 'react-query';
 import invariant from 'tiny-invariant';
@@ -27,6 +26,7 @@ import { DeleteAccount } from '~features/delete-account';
 import { MeasurementsTable } from '~features/measurements/table';
 import { useProfile } from '~hooks/use-profile';
 import { type Database } from '~types/supabase';
+import { getServerSideTranslations } from '~util/i18n';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
     const supabase = createPagesServerClient<Database>(context);
@@ -50,9 +50,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
     return {
         props: {
-            ...(await serverSideTranslations(profile?.language || 'en', [
-                'common',
-            ])),
+            ...(await getServerSideTranslations({ locale: profile?.language })),
         },
     };
 };

--- a/src/util/i18n.ts
+++ b/src/util/i18n.ts
@@ -1,0 +1,9 @@
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+
+const allLocales = ['gr', 'en'];
+
+export const getServerSideTranslations = async ({
+    locale,
+}: {
+    locale?: string;
+}) => serverSideTranslations(locale || 'en', ['common'], null, allLocales);


### PR DESCRIPTION
There was a bug when the user changed their language, the messages where shown in the previously configured locale until they refreshed the page. This PR fixes this by, perhaps naively, loading both locales on all routes. It is a pretty small file for now, so it does not make any impact.