### PR TITLE
Keep local changes visible until query settles [PLA-36]

### DIFF
--- a/src/features/calendar/calendar.module.css
+++ b/src/features/calendar/calendar.module.css
@@ -3,5 +3,4 @@
     --grid-gap: 0.5rem;
     display: grid;
     gap: var(--grid-gap);
-    position: relative;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -42,12 +42,11 @@ a {
     background-color: var(--color-primary);
 }
 
-/* Home page  */
-
 .container {
     border-top: 5px solid var(--color-primary);
     height: 100%;
     padding: 2rem;
+    position: relative;
     background: #ecf5ec;
 }
 


### PR DESCRIPTION
This PR keeps the local changes the user has made to a meal plan visible unti the GET query settles. It also makes the loader take the whole page container, not just the calendar element.